### PR TITLE
Hackergarten Luzern: Added a link to doodle

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
             <section id="events">
                 <h2>Next Events</h2>
                 <ul>
+                    <li>
+                        next Hackergarten <b>in Lucerne</b> <a href="http://doodle.com/32xr2y5iufyes6wp">is being planned</a> - <a href="http://doodle.com/32xr2y5iufyes6wp">vote on Doodle</a>
+                    </li>
             	  <li>Hack #46 - 30th october 2014 - Basel, Canoo Office -
                         <a href="https://groups.google.com/forum/#!topic/hackergarten/b4VqwExj5-c">GoogleGroups</a>,
                         <a href="http://www.meetup.com/Hackergarten-Basel/events/211695852/">Meetup</a>


### PR DESCRIPTION
The planning for the next Hackergarten in Lucerne has started.
