### PR TITLE
Hackergarten Lucerne September 2015 cancelled

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,12 +1,12 @@
 [
   {
-    "date": "2015-09-03",
+    "date": "2015-10-01",
     "location": "Lucerne, Switzerland",
     "title": "at CSS Versicherung",
     "links": [
       {
         "title": "Meetup",
-        "url": "http://www.meetup.com/Hackergarten-Luzern/events/hjxkglytmbfb/"
+        "url": "http://www.meetup.com/Hackergarten-Luzern/events/hjxkglytnbcb/"
       },
       {
         "title": "How to find us",


### PR DESCRIPTION
Next Hackergarten Lucerne will be on 1st October 2015 at 6 pm