### PR TITLE
removed broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,6 @@
                 <div class="panel-body">
                     <ul>
                         <li><a href="http://groups.google.com/group/hackergarten/">Official Google Group Mailing List</a></li>
-                        <li><a href="http://hackergarten.wikispaces.com/">Wikispaces</a>
                         <li><a href="http://github.com/hackergarten">Public Git Repository</a><br>
                         <li><a href="http://www.twitter.com/Hackergarten">@Hackergarten on Twitter</a></li>
                         <li><a href="https://www.facebook.com/pages/Hackergarten/155381234519676">Facebook Fanpage</a></li>


### PR DESCRIPTION
Removed the [Wikispaces](http://hackergarten.wikispaces.com/) link 'cause it's just saying the subscription is expired