### PR TITLE
Validator for events json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+before_script:
+  - npm install -g gulp
+script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 before_script:
-  - npm install gulp
+  - npm install
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 before_script:
-  - npm install -g gulp
+  - npm install gulp
 script: gulp

--- a/events.json
+++ b/events.json
@@ -41,7 +41,7 @@
       {
         "title": "Meetup",
         "url": "http://www.meetup.com/de-DE/Hackergarten-Basel/events/231793848/"
-      }
+      },
       {
         "title": "where is Canoo Office",
         "url": "http://www.canoo.com/service/contact/?l=en"

--- a/events.json
+++ b/events.json
@@ -34,6 +34,23 @@
     ]
   },
   {
+    "date": "2016-06-30",
+    "location": "Basel, Switzerland",
+    "title": "at Canoo Office",
+    "links": [
+      {
+        "title": "Meetup",
+        "url": "http://www.meetup.com/de-DE/Hackergarten-Basel/events/231793848/"
+      }
+      {
+        "title": "where is Canoo Office",
+        "url": "http://www.canoo.com/service/contact/?l=en"
+      }
+      ],
+    "achievements": [
+    ]
+  },
+  {
     "date": "2016-06-02",
     "location": "Lucerne, Switzerland",
     "title": "at CSS Versicherung",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,15 @@
+var gulp = require('gulp');
+
+var jsonlint = require("gulp-jsonlint");
+ 
+var gulp = require('gulp');
+
+gulp.task('default', function() {
+
+	gulp.src("./events.json")
+	    .pipe(jsonlint())
+		.pipe(jsonlint.failOnError())
+	    .pipe(jsonlint.reporter());
+ 
+});
+ 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hackergarten.github.io",
+  "version": "1.0.0",
+  "description": "hackergarten.github.io ======================",
+  "main": "gulpfile.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hackergarten/hackergarten.github.io.git"
+  },
+  "keywords": [
+    "Hackergarten",
+    "Homepage"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/hackergarten/hackergarten.github.io/issues"
+  },
+  "homepage": "https://github.com/hackergarten/hackergarten.github.io#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-jsonlint": "^1.1.2"
+  }
+}


### PR DESCRIPTION
Add a simple gulp build to validate the events.json 

should make it easier for PR to make at least sure that the events file is syntactically correct
also add next Hackergarten Basel