### PR TITLE
Events can now have a status, resolves #137

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -32,6 +32,11 @@ li.rescheduled {
 	background-color: #fffe86;
 }
 
+li.canceled span:first-child {
+    color: #AAAAAA;
+    text-decoration: line-through;
+}
+
 .jumbotron .container {
     position: relative;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -37,6 +37,10 @@ li.canceled span:first-child {
     text-decoration: line-through;
 }
 
+span.reason {
+    font-weight: bold;
+}
+
 .jumbotron .container {
     position: relative;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -28,6 +28,10 @@
 	background-color: #74ED8C;
 }
 
+li.rescheduled {
+	background-color: #fffe86;
+}
+
 .jumbotron .container {
     position: relative;
 }

--- a/index.html
+++ b/index.html
@@ -46,17 +46,17 @@
                 <div class="panel-heading">Next Events</div>
                 <div class="panel-body">
                     <ul>
-                        <li id="event-{{event.hashCode}}" class="next-event {{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in nextEventlist">
+                        <li id="event-{{event.hashCode}}" class="next-event {{event.status.key}}" title="{{event.status.title}}" ng-repeat="event in nextEventlist">
                             <span><b>Hack #{{allEventlistLength - $index}} {{event.title}}</b></span>
-                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
+                            <span class="reason" ng-if="event.status.title"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>
                         </li>
 
-                        <li id="event-{{event.hashCode}}" class="{{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in futureEventlist">
+                        <li id="event-{{event.hashCode}}" class="{{event.status.key}}" title="{{event.status.title}}" ng-repeat="event in futureEventlist">
                             <span>Hack #{{allEventlistLength + $index + 1}} {{event.title}}</span>
-                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
+                            <span class="reason" ng-if="event.status.title"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>
@@ -80,9 +80,9 @@
                 <div class="panel-heading">Past Events</div>
                 <div class="panel-body scrollable">
                     <ul>
-                        <li id="event-{{event.hashCode}}" class="{{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in pastEventlist | limitTo:totalPEventDisplayed">
+                        <li id="event-{{event.hashCode}}" class="{{event.status.key}}" title="{{event.status.title}}" ng-repeat="event in pastEventlist | limitTo:totalPEventDisplayed">
                             <span>Hack #{{pastEventlistLength - $index}} {{event.title}}</span>
-                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
+                            <span class="reason" ng-if="event.status.title"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>

--- a/index.html
+++ b/index.html
@@ -46,15 +46,17 @@
                 <div class="panel-heading">Next Events</div>
                 <div class="panel-body">
                     <ul>
-                        <li id="event-{{event.hashCode}}" class="next-event" ng-repeat="event in nextEventlist">
-                            <b>Hack #{{allEventlistLength - $index}} {{event.title}}</b>
+                        <li id="event-{{event.hashCode}}" class="next-event {{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in nextEventlist">
+                            <span><b>Hack #{{allEventlistLength - $index}} {{event.title}}</b></span>
+                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>
                         </li>
 
-                        <li id="event-{{event.hashCode}}" ng-repeat="event in futureEventlist">
-                            Hack #{{allEventlistLength + $index + 1}} {{event.title}}
+                        <li id="event-{{event.hashCode}}" class="{{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in futureEventlist">
+                            <span>Hack #{{allEventlistLength + $index + 1}} {{event.title}}</span>
+                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>
@@ -78,8 +80,9 @@
                 <div class="panel-heading">Past Events</div>
                 <div class="panel-body scrollable">
                     <ul>
-                        <li id="event-{{event.hashCode}}" ng-repeat="event in pastEventlist | limitTo:totalPEventDisplayed">
-                            Hack #{{pastEventlistLength - $index}} {{event.title}}
+                        <li id="event-{{event.hashCode}}" class="{{event.status.pizza}}" title="{{event.status.title}}" ng-repeat="event in pastEventlist | limitTo:totalPEventDisplayed">
+                            <span>Hack #{{pastEventlistLength - $index}} {{event.title}}</span>
+                            <span class="reason" ng-if="event.status.reason"><br/>&rarr; {{event.status.title}}</span>
                             <ul ng-if="event.links.length > 0">
                                 <li ng-repeat="link in event.links"><a href="{{link.url}}">{{link.title}}</a></li>
                             </ul>

--- a/scripts/eventlist.js
+++ b/scripts/eventlist.js
@@ -15,6 +15,9 @@ app.filter('html', ['$sce', function ($sce) {
     };    
 }]);
 
+var today = new Date();
+today = new Date(today.setHours(0, 0, 0));
+
 function hashCode(str) {
     var hash = 0;
     if (str.length == 0) return hash;
@@ -73,6 +76,15 @@ function eventService($http) {
         return (isLess ? 1 : -1);
     };
 
+    var generateStatus = function(event) {
+        if (!event.status) {
+            event.status = {
+                "pizza": new Date(event.date) < today ? "past" : "scheduled"
+            };
+        }
+        return event;
+    };
+
     var generateHashCode = function(event) {
         event.hashCode = hashCode(event.date + event.location);
         return event;
@@ -106,14 +118,13 @@ function eventService($http) {
     };
 
     var eventList = [];
-    var today = new Date();
-    today = new Date(today.setHours(0, 0, 0));
 
     return {
         queryEvents: function () {
             return $http.get('events.json').then(function (response) {
                 eventList = response.data;
                 eventList.sort(sortEventsByDate);
+                eventList.map(generateStatus);
                 eventList.map(generateHashCode);
                 eventList.map(generateTitle);
                 eventList.map(generateMapLink);

--- a/scripts/eventlist.js
+++ b/scripts/eventlist.js
@@ -81,6 +81,8 @@ function eventService($http) {
             event.status = {
                 "pizza": new Date(event.date) < today ? "past" : "scheduled"
             };
+        } else {
+            event.status.title = event.status.pizza.toUpperCase() + ": " + event.status.reason;
         }
         return event;
     };

--- a/scripts/eventlist.js
+++ b/scripts/eventlist.js
@@ -79,10 +79,10 @@ function eventService($http) {
     var generateStatus = function(event) {
         if (!event.status) {
             event.status = {
-                "pizza": new Date(event.date) < today ? "past" : "scheduled"
+                "key": new Date(event.date) < today ? "past" : "scheduled"
             };
         } else {
-            event.status.title = event.status.pizza.toUpperCase() + ": " + event.status.reason;
+            event.status.title = event.status.key.toUpperCase() + ": " + event.status.reason;
         }
         return event;
     };


### PR DESCRIPTION
The `events.json` now supports defining an optional status. Actually, two explicit states are supported:

**Rescheduled**
```
    {
        "date": "…",
        "venue": "…",
        "address": "…",
        "status": {
            "key": "rescheduled",
            "reason": "Date conflict with conference"
        }
    },
```

**Canceled**
```
    {
        "date": "…",
        "venue": "…",
        "address": "…",
        "status": {
            "key": "canceled",
            "reason": "We run out of beer"
        }
    },
```

Events with these two states are marked in the rendered output and show the reason, for example:

**Rescheduled**
Yellow background with status and reason:
<img width="490" alt="bildschirmfoto 2018-10-04 um 22 20 31" src="https://user-images.githubusercontent.com/1254039/46500716-d05d8300-c823-11e8-9bf2-9cc3974396d3.png">

**Canceled**
Greyed out text, strike through, with reason:
<img width="439" alt="bildschirmfoto 2018-10-04 um 22 20 55" src="https://user-images.githubusercontent.com/1254039/46500754-e10df900-c823-11e8-9a1c-69f4c2884230.png">

*Comments welcome!*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackergarten/hackergarten.github.io/180)
<!-- Reviewable:end -->
