### PR TITLE
Fixing broken twitter timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,16 +126,9 @@
             </div>
 
             <div class="panel panel-default">
+                <div class="panel-heading">Twitter</div>
                 <div class="panel-body">
-                    <a class="twitter-timeline" href="https://twitter.com/search?q=%23hackergarten" data-widget-id="428946456414666752">Tweets about &quot;#hackergarten&quot;</a>
-                    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-                </div>
-            </div>
-
-            <div class="panel panel-default">
-                <div class="panel-body">
-                    <a class="twitter-timeline" href="https://twitter.com/search?q=%40hackergarten" data-widget-id="428953538593439744">Tweets about "@hackergarten"</a>
-                    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+                    <a class="twitter-timeline" data-width="500" data-height="500" data-dnt="true" data-link-color="#428bca" href="https://twitter.com/Hackergarten?ref_src=twsrc%5Etfw">Tweets by Hackergarten</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                 </div>
             </div>
 


### PR DESCRIPTION
Embedding '@hackergarten' tweets works fine now, but embedding #hackergarten is not possible anymore. Twitter has disabled the possibility to embed searches for hashtags "for technical reasons".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackergarten/hackergarten.github.io/199)
<!-- Reviewable:end -->
