### PR TITLE
Add link to join slack workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                 <div id="joinSection" class="panel-heading">Join</div>
                 <div class="panel-body">
                     <ul>
-                        <li><a href="https://join.slack.com/t/hackergarten-chat/shared_invite/enQtNTkxMDY5NjgxNDkwLTUxNTJiMGNjZTgxMTlmM2VkYTkxZjRkOGU3MmE4OWJhMDJlMDdjZmIyZmMyMDE3NzYxMWJjN2U1NTYyZjkxZGE">Slack Community</a></li>
+                        <li><a href="https://forms.gle/93guiZ3rXtW4azdo6">Slack Community</a></li>
                         <li><a href="feed.xml">Hackergarten Events RSS Feed</a></li>
                         <li><a href="http://github.com/hackergarten">Public Git Repository</a><br>
                         <li><a href="http://www.twitter.com/Hackergarten">@Hackergarten on Twitter</a></li>

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
                 <div id="joinSection" class="panel-heading">Join</div>
                 <div class="panel-body">
                     <ul>
+                        <li><a href="https://join.slack.com/t/hackergarten-chat/shared_invite/enQtNTkxMDY5NjgxNDkwLTUxNTJiMGNjZTgxMTlmM2VkYTkxZjRkOGU3MmE4OWJhMDJlMDdjZmIyZmMyMDE3NzYxMWJjN2U1NTYyZjkxZGE">Slack Community</a></li>
                         <li><a href="feed.xml">Hackergarten Events RSS Feed</a></li>
                         <li><a href="http://github.com/hackergarten">Public Git Repository</a><br>
                         <li><a href="http://www.twitter.com/Hackergarten">@Hackergarten on Twitter</a></li>

--- a/index.html
+++ b/index.html
@@ -140,11 +140,11 @@
                 <div id="joinSection" class="panel-heading">Join</div>
                 <div class="panel-body">
                     <ul>
-                        <li><a href="https://forms.gle/93guiZ3rXtW4azdo6">Slack Community</a></li>
                         <li><a href="feed.xml">Hackergarten Events RSS Feed</a></li>
                         <li><a href="http://github.com/hackergarten">Public Git Repository</a><br>
                         <li><a href="http://www.twitter.com/Hackergarten">@Hackergarten on Twitter</a></li>
-                        <li><a href="https://www.facebook.com/pages/Hackergarten/155381234519676">Facebook Fanpage</a></li>
+                        <li><a href="https://gitter.im/hackergarten?utm_source=share-link&utm_medium=link&utm_campaign=share-link">Gitter</a></li>
+                        <li><a href="https://forms.gle/93guiZ3rXtW4azdo6">Slack Community</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Links to a google form which uses Zapier to generate a Slack invite link for the entered email