### PR TITLE
JWild was postponed to 2021

### DIFF
--- a/events.json
+++ b/events.json
@@ -9,7 +9,11 @@
                 "url": "https://www.meetup.com/Hackergarten-Luzern/events/jfqzmqybcqbfb/"
             }
         ],
-        "achievements": []
+        "achievements": [],
+        "status": {
+            "key": "canceled",
+            "reason": "Due to the current situation regarding the corona virus."
+        }
     },
     {
         "date": "2020-11-05",
@@ -21,7 +25,11 @@
                 "url": "https://www.meetup.com/Hackergarten-Luzern/events/jfqzmqybcpbhb/"
             }
         ],
-        "achievements": []
+        "achievements": [],
+        "status": {
+            "key": "canceled",
+            "reason": "Due to the current situation regarding the corona virus."
+        }
     },
     {
         "title": "Hackergarten JWild",

--- a/events.json
+++ b/events.json
@@ -42,7 +42,11 @@
                 "url": "https://wilderness-software.com/jwild-2020/"
             }
         ],
-        "achievements": []
+        "achievements": [],
+        "status": {
+            "key": "rescheduled",
+            "reason": "Unfortunately postponed to 2021"
+        }
     },
     {
         "date": "2020-10-01",


### PR DESCRIPTION
@aalmiray, thank you very much for merging my PR so fast! As I was checking the result, I have seen the announcement of JWild Hackergarten still on the Hackergarten website, but JWild is postponed to 2021. Sorry for not recognizing this before my previous PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackergarten/hackergarten.github.io/316)
<!-- Reviewable:end -->
