### PR TITLE
Add location section that shows active Hackergarten locations

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -80,3 +80,10 @@ span.reason {
     height: 100px;
     width: 100px;
 }
+
+#map {
+    height: 350px;
+}
+#map .location-marker {
+    font-size: 16px;
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
     <link href="ng-dialog/css/ngDialog.min.css" rel="stylesheet">
     <link href="ng-dialog/css/ngDialog-theme-default.min.css" rel="stylesheet">
 
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
+          integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI="
+          crossorigin=""/>
+
     <link href="css/main.css" rel="stylesheet">
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
@@ -71,6 +75,14 @@
                 <div class="panel-heading">About</div>
                 <div class="panel-body">
                     Hackergarten is a craftmen's workshop, classroom, a laboratory, a social circle, a writing group, a playground, and an artist's studio. Our goal is to create something that others can use; whether it be working software, improved documentation, or better educational materials. Our intent is to end each meeting with a patch or similar contribution submitted to an open and public project. Membership is open to anyone willing to contribute their time.
+                </div>
+            </div>
+
+            <!-- locations -->
+            <div class="panel panel-default">
+                <div class="panel-heading">Locations</div>
+                <div class="panel-body">
+                    <div id="map"></div>
                 </div>
             </div>
 
@@ -245,12 +257,16 @@
 <script src="https://cdn.jsdelivr.net/bootstrap/3.3.0/js/bootstrap.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/js-xss/0.3.3/xss.js"></script>
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
+        integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM="
+        crossorigin=""></script>
 
 <script src="ng-dialog/js/ngDialog.js"></script>
 
 <script src="scripts/hgMainPage.js"></script>
 <script src="scripts/eventlist.js"></script>
 <script src="scripts/github.js"></script>
+<script src="scripts/locations.js"></script>
 
 <script src="scripts/mastodon.widget.js"></script>
 <script>

--- a/scripts/locations.js
+++ b/scripts/locations.js
@@ -1,0 +1,43 @@
+$(document).ready(function () {
+    var map = L.map("map");
+    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        maxZoom: 19,
+        attribution:
+            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map);
+
+    var markers = locations.map((location) =>
+        L.marker([location.lat, location.lon]).bindPopup(
+            '<span class="location-marker">' + location.venue + "</span>"
+        )
+    );
+    markers.forEach((marker) => {
+        marker.addTo(map);
+    });
+
+    var group = new L.featureGroup(markers);
+    map.fitBounds(group.getBounds());
+});
+
+var locations = [
+    {
+        venue: "Quatico Solutions AG",
+        lat: 47.3925495,
+        lon: 8.507826793619888,
+    },
+    {
+        venue: "codecentric AG",
+        lat: 48.72592,
+        lon: 9.1144,
+    },
+    {
+        venue: "CSS Versicherung",
+        lat: 47.0435895,
+        lon: 8.315118,
+    },
+    {
+        venue: "Karakun AG",
+        lat: 47.5487602,
+        lon: 7.5879349,
+    },
+];


### PR DESCRIPTION
At Hack 322 we worked on a first simple version of a location map. The map shows active Hackergarten locations with their venues. Further locations can be added by enhancing the `locations` list in `scripts/locations.js`

<img width="673" alt="Bildschirm­foto 2023-03-07 um 21 31 57" src="https://user-images.githubusercontent.com/35852798/223545520-e07fb086-7707-4933-8d97-788a7dd264d1.png">

Further improvements we thought about:
- collect locations from `events.json` and map addresses to geo locations
- mark locations with no recent events as "inactive"
- add meta information like meetup groups to the location pop-up

Fixes #12 

co-authors: @wandertaker, @WtfJoke, Jakob