### PR TITLE
Add all events for Hackergarten Stuttgart in 2025

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,5 +1,149 @@
 [
     {
+        "date": "2025-12-02",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576942/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-11-04",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576939/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-10-07",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576938/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-09-02",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576936/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-08-05",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576917/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-07-01",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576916/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-06-03",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576913/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-05-06",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576912/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-04-01",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576908/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-03-04",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576907/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-02-04",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576898/"
+            }
+        ],
+        "achievements": []
+    },
+    {
+        "date": "2025-01-07",
+        "venue": "codecentric AG",
+        "address": "Industriestraße 3, 70565 Stuttgart, Germany",
+        "links": [
+            {
+                "title": "Meetup",
+                "url": "https://www.meetup.com/hackergarten-stuttgart/events/304576896/"
+            }
+        ],
+        "achievements": []
+    },
+    {
         "date": "2024-12-05",
         "venue": "CSS Versicherung",
         "address": "Rösslimatte 52, 6005 Luzern",


### PR DESCRIPTION
In 2025, we would again like to host the Hackergarten in Stuttgart at our office.