### PR TITLE
Update events.json

### DIFF
--- a/events.json
+++ b/events.json
@@ -31,7 +31,7 @@
         "links": [
             {
                 "title": "Meetup",
-                "url": "https://www.meetup.com/hackergarten-basel/events/306831769/"
+                "url": "https://www.meetup.com/hackergarten-basel/events/309859141/"
             }
         ],
         "achievements": []
@@ -81,7 +81,7 @@
         "links": [
             {
                 "title": "Meetup",
-                "url": "https://www.meetup.com/hackergarten-basel/events/306831769/"
+                "url": "https://www.meetup.com/hackergarten-basel/events/309859111/"
             }
         ],
         "achievements": []
@@ -106,7 +106,7 @@
         "links": [
             {
                 "title": "Meetup",
-                "url": "https://www.meetup.com/hackergarten-basel/events/306831769/"
+                "url": "https://www.meetup.com/hackergarten-basel/events/309857779/"
             }
         ],
         "achievements": []
@@ -168,7 +168,7 @@
         "links": [
             {
                 "title": "Meetup",
-                "url": "https://www.meetup.com/hackergarten-basel/events/306831769/"
+                "url": "https://www.meetup.com/hackergarten-basel/events/309853513/"
             }
         ],
         "achievements": []


### PR DESCRIPTION
Update Meetup links for the Hackergarten Basel events on the following dates: 27.08.2025
01.10.2025
29.10.2025
26.11.2025