### PR TITLE
Move OpenClaw achievement to Basel event

### DIFF
--- a/events.json
+++ b/events.json
@@ -141,12 +141,7 @@
                 "url": "https://www.meetup.com/hackergarten-zurich/events/313127411/"
             }
         ],
-        "achievements": [
-            {
-                "title": "OpenClaw: Triage on #84607 'Bug: No automatic retry with fallback when primary model returns overloaded_error'",
-                "url": "https://github.com/openclaw/openclaw/issues/84607#issuecomment-4500808188"
-            }
-        ]
+        "achievements": []
     },
     {
         "date": "2026-05-20",
@@ -160,9 +155,13 @@
             }
         ],
         "achievements": [
-                        {
+            {
                 "title": "githup-speckit: Triage on #1030 'md linting errors'",
                 "url": "https://github.com/github/spec-kit/issues/1030#issuecomment-4501717345"
+            },
+            {
+                "title": "OpenClaw: Triage on #84607 'Bug: No automatic retry with fallback when primary model returns overloaded_error'",
+                "url": "https://github.com/openclaw/openclaw/issues/84607#issuecomment-4500808188"
             }
         ]
     },


### PR DESCRIPTION
## Summary

Move the OpenClaw triage achievement from the Zurich May 2026 event to the Basel May 2026 event, which took place on 2026-05-20.

## Why

The achievement belongs to the Basel event from that date, not the later Zurich event.

## Testing

- `python3 -m json.tool events.json`
- `npm run gulp`

## AI Disclosure

This PR was prepared with help from OpenClaw. The change was reviewed against the local diff, and the project validation commands above were run before submission.
